### PR TITLE
Support to dynamically link with libsgx_launch.so for psw

### DIFF
--- a/psw/ae/aesm_service/source/bundles/le_launch_service_bundle/le_launch_service_bundle.cpp
+++ b/psw/ae/aesm_service/source/bundles/le_launch_service_bundle/le_launch_service_bundle.cpp
@@ -21,8 +21,6 @@ extern "C" bool is_launch_token_required();
 extern ae_error_t start_white_list_thread(unsigned long timeout=THREAD_TIMEOUT);
 extern ThreadStatus white_list_thread;
 
-extern "C" void init_get_launch_token(const func_get_launch_token_t func);
-
 extern "C" sgx_status_t get_launch_token(const enclave_css_t *signature,
                                          const sgx_attributes_t *attribute,
                                          sgx_launch_token_t *launch_token)
@@ -174,7 +172,6 @@ private:
         auto context = cppmicroservices::GetBundleContext();
         get_service_wrapper(g_network_service, context);
         get_service_wrapper(g_launch_service, context);
-        init_get_launch_token(::get_launch_token);
         start_white_list_thread(0);
         initialized = true;
         AESM_DBG_INFO("le bundle started");

--- a/psw/enclave_common/Makefile
+++ b/psw/enclave_common/Makefile
@@ -51,13 +51,13 @@ INC += -I$(COMMON_DIR)/inc                \
        -I$(LINUX_PSW_DIR)/urts/linux      \
        -I$(LINUX_PSW_DIR)/enclave_common
 
-LDFLAGS := -lwrapper -ldl
+LDFLAGS := -lwrapper -lsgx_launch
 LDFLAGS += $(COMMON_LDFLAGS) -Wl,--version-script=sgx_enclave_common.lds -Wl,--gc-sections
 
 DIR1 := $(LINUX_PSW_DIR)/enclave_common
 DIR2 := $(LINUX_PSW_DIR)/urts/linux
 
-LIB += -L$(COMMON_DIR)/se_wrapper_psw
+LIB += -L$(COMMON_DIR)/se_wrapper_psw -L$(LINUX_PSW_DIR)/uae_service/linux
 
 OBJ := sgx_enclave_common.o edmm_utility.o
 

--- a/psw/enclave_common/sgx_enclave_common.cpp
+++ b/psw/enclave_common/sgx_enclave_common.cpp
@@ -48,14 +48,6 @@
 
 #define POINTER_TO_U64(A) ((__u64)((uintptr_t)(A)))
 
-#define SGX_LAUNCH_SO "libsgx_launch.so.1"
-#define SGX_GET_LAUNCH_TOKEN "get_launch_token"
-
-func_get_launch_token_t get_launch_token_func = NULL;
-
-static void* s_hdlopen = NULL;
-static se_mutex_t s_dlopen_mutex;
-
 static se_mutex_t s_device_mutex;
 static se_mutex_t s_enclave_mutex;
 
@@ -176,54 +168,16 @@ extern "C" void* get_enclave_base_address_from_address(void* target_address)
 
 }
 
-static func_get_launch_token_t get_launch_token_function(void)
-{
-    if (get_launch_token_func == NULL) {
-        se_mutex_lock(&s_dlopen_mutex);
-        if (get_launch_token_func != NULL)
-        {
-            se_mutex_unlock(&s_dlopen_mutex);
-            return get_launch_token_func;
-        }
-
-        if (s_hdlopen == NULL) {
-            s_hdlopen = dlopen(SGX_LAUNCH_SO, RTLD_LAZY);
-            if (s_hdlopen == NULL) {
-                se_mutex_unlock(&s_dlopen_mutex);
-                return NULL;
-            }
-        }
-
-        get_launch_token_func = (func_get_launch_token_t)dlsym(s_hdlopen, SGX_GET_LAUNCH_TOKEN);
-        se_mutex_unlock(&s_dlopen_mutex);
-    }
-
-    return get_launch_token_func;
-}
-
-static void close_sofile(void)
-{
-    se_mutex_lock(&s_dlopen_mutex);
-    if (s_hdlopen != NULL) {
-        dlclose(s_hdlopen);
-        s_hdlopen = NULL;
-    }
-    se_mutex_unlock(&s_dlopen_mutex);
-}
-
 static void __attribute__((constructor)) enclave_init(void)
 {
     se_mutex_init(&s_device_mutex);
-    se_mutex_init(&s_dlopen_mutex);
     se_mutex_init(&s_enclave_mutex);
 }
 
 static void __attribute__((destructor)) enclave_fini(void)
 {
     close_device();
-    close_sofile();
     se_mutex_destroy(&s_device_mutex);
-    se_mutex_destroy(&s_dlopen_mutex);
     se_mutex_destroy(&s_enclave_mutex);
 }
 
@@ -784,15 +738,7 @@ extern "C" bool COMM_API enclave_initialize(
 
         enclave_css_t* enclave_css = (enclave_css_t*)enclave_init_sgx->sigstruct;
         if (0 == enclave_css->header.hw_version) {
-            func_get_launch_token_t func = get_launch_token_function();
-            if (func == NULL) {
-                SE_TRACE(SE_TRACE_WARNING, "Failed to get sysmbol %s from %s.\n", SGX_GET_LAUNCH_TOKEN, SGX_LAUNCH_SO);
-                if (enclave_error != NULL)
-                    *enclave_error = ENCLAVE_UNEXPECTED;
-                return false;
-            }
-
-            sgx_status_t status = func(enclave_css, &it->second, &launch_token);
+            sgx_status_t status = get_launch_token(enclave_css, &it->second, &launch_token);
             if (status != SGX_SUCCESS) {
                 if (enclave_error != NULL)
                     *enclave_error = error_aesm2api(status);

--- a/psw/urts/linux/Makefile
+++ b/psw/urts/linux/Makefile
@@ -59,7 +59,7 @@ INTERNAL_LDFLAGS := -lwrapper
 LDFLAGS += $(COMMON_LDFLAGS) -Wl,-Bdynamic -L$(BUILD_DIR) -lsgx_enclave_common -lpthread
 INTERNAL_LDFLAGS += $(COMMON_LDFLAGS) -lpthread
 LDFLAGS += -L$(VTUNE_DIR)/sdk/src/ittnotify -littnotify -ldl
-INTERNAL_LDFLAGS += -L$(VTUNE_DIR)/sdk/src/ittnotify -littnotify -ldl
+INTERNAL_LDFLAGS += -L$(VTUNE_DIR)/sdk/src/ittnotify -littnotify -lsgx_launch
 LDFLAGS += -Wl,--version-script=urts.lds -Wl,--gc-sections
 INTERNAL_LDFLAGS += -Wl,--version-script=urts_internal.lds -Wl,--gc-sections
 
@@ -70,7 +70,8 @@ DIR4 := $(LINUX_PSW_DIR)/urts/parser/linux
 DIR5 := $(LINUX_PSW_DIR)/../common/src/linux
 
 LIB += -L$(COMMON_DIR)/se_wrapper_psw \
-       -L$(SGX_LIB_DIR)
+       -L$(SGX_LIB_DIR) \
+       -L$(LINUX_PSW_DIR)/uae_service/linux
 
 OBJ1 := loader.o          \
         node.o            \

--- a/psw/urts/linux/urts_internal.cpp
+++ b/psw/urts/linux/urts_internal.cpp
@@ -45,14 +45,6 @@
 
 extern sgx_status_t _create_enclave(const bool debug, se_file_handle_t pfile, se_file_t& file, le_prd_css_file_t *prd_css_file, sgx_launch_token_t *launch, int *launch_updated, sgx_enclave_id_t *enclave_id, sgx_misc_attribute_t *misc_attr);
 
-extern func_get_launch_token_t get_launch_token_func;
-
-extern "C" void init_get_launch_token(const func_get_launch_token_t func)
-{
-    get_launch_token_func = func;
-}
-
-
 extern "C" sgx_status_t sgx_create_le(const char* file_name, const char* prd_css_file_name, const int debug, sgx_launch_token_t *launch_token, int *launch_token_updated, sgx_enclave_id_t *enclave_id, sgx_misc_attribute_t *misc_attr, int *production_loaded)
 {
     sgx_status_t ret = SGX_SUCCESS;

--- a/psw/urts/linux/urts_internal.lds
+++ b/psw/urts/linux/urts_internal.lds
@@ -21,7 +21,6 @@
         is_launch_token_required;
         sgx_get_metadata;
         sgx_set_switchless_itf;
-        init_get_launch_token;
     local:
         *;
 };


### PR DESCRIPTION
In order to implement dynamic link with libsgx_launch.so, the logic of
dlopen() should be dropped.

In addition, Intel LE from AEs still depends on init_get_launch_token()
so just level it with an empty function body.

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>