### PR TITLE
Support longjmp in exception handler

### DIFF
--- a/sdk/trts/trts_veh.cpp
+++ b/sdk/trts/trts_veh.cpp
@@ -229,7 +229,8 @@ extern "C" __attribute__((regparm(1))) void internal_handle_exception(sgx_except
         continue_execution(info);
     }
 
-    if ((nhead = (uintptr_t *)malloc(size)) == NULL)
+    // The customer handler may never return, use alloca instead of malloc 
+    if ((nhead = (uintptr_t *)alloca(size)) == NULL)
     {
         sgx_spin_unlock(&g_handler_lock);
         goto failed_end;
@@ -246,6 +247,10 @@ extern "C" __attribute__((regparm(1))) void internal_handle_exception(sgx_except
     // read unlock
     sgx_spin_unlock(&g_handler_lock);
 
+    // decrease the nested exception count before the customer
+    // handler execution, becasue the handler may never return
+    thread_data->exception_flag--;
+
     // call exception handler until EXCEPTION_CONTINUE_EXECUTION is returned
     ntmp = nhead;
     while(size > 0)
@@ -259,7 +264,6 @@ extern "C" __attribute__((regparm(1))) void internal_handle_exception(sgx_except
         ntmp++;
         size -= sizeof(sgx_exception_handler_t);
     }
-    free(nhead);
 
     standard_exception = is_standard_exception(info->cpu_context.REG(ip));
 
@@ -272,12 +276,7 @@ extern "C" __attribute__((regparm(1))) void internal_handle_exception(sgx_except
         goto failed_end;
     }
 
-    if(EXCEPTION_CONTINUE_EXECUTION == status)
-    {
-        //exception is handled, decrease the nested exception count
-        thread_data->exception_flag--;
-    }
-    else
+    if(EXCEPTION_CONTINUE_EXECUTION != status)
     {
         //exception cannot be handled
         thread_data->exception_flag = -1;


### PR DESCRIPTION
If the customer exception handler use longjmp function, then the memory free would be skipped. So the malloc should be changed to alloca.