### PR TITLE
Fix create enclave failed due to ENOMEM in simulation mode

### DIFF
--- a/common/src/se_memory.c
+++ b/common/src/se_memory.c
@@ -38,7 +38,8 @@
 void* se_virtual_alloc(void* address, size_t size, uint32_t type)
 {
     UNUSED(type);
-    void* pRet = mmap(address, size, PROT_READ | PROT_WRITE, MAP_PRIVATE |  MAP_ANONYMOUS, -1, 0);
+    int protection = PROT_NONE; // Memory just reserved, not committed.
+    void* pRet = mmap(address, size, protection, MAP_PRIVATE |  MAP_ANONYMOUS, -1, 0);
     if(MAP_FAILED == pRet)
         return NULL;
     return pRet;

--- a/sdk/simulation/uinst/u_instructions.cpp
+++ b/sdk/simulation/uinst/u_instructions.cpp
@@ -359,8 +359,6 @@ uintptr_t _ECREATE(page_info_t* pi)
         return 0;
     }
 
-    // Mark all the memory inaccessible.
-    se_virtual_protect(addr, (size_t)secs->size, SGX_PROT_NONE);
     ce->get_secs()->base = addr;
 
     CEnclaveMngr::get_instance()->add(ce);


### PR DESCRIPTION
In simulation mode, previously, ECREATE will commit all the pages which will cause ENOMEM if the size is very big.

This patch fixed this by only reserving the pages (with PROT_NONE) in ECREATE but committing the pages in EADD.