### PR TITLE
Disable vdso support temporarily

### DIFF
--- a/psw/urts/linux/sig_handler.cpp
+++ b/psw/urts/linux/sig_handler.cpp
@@ -435,10 +435,12 @@ static void __attribute__((constructor)) vdso_detector(void)
 #ifdef SE_SIM
     vdso_sgx_enter_enclave = NULL;
 #else  
-    if(vdso_sgx_enter_enclave == NULL)
-    {
-        vdso_sgx_enter_enclave = (vdso_sgx_enter_enclave_t)get_vdso_sym("__vdso_sgx_enter_enclave");
-    }
+    // TODO: We disable vdso support in Occlum's SGX SDK temporarily
+    vdso_sgx_enter_enclave = NULL;
+    // if(vdso_sgx_enter_enclave == NULL)
+    // {
+    //     vdso_sgx_enter_enclave = (vdso_sgx_enter_enclave_t)get_vdso_sym("__vdso_sgx_enter_enclave");
+    // }
 #endif
 }
 


### PR DESCRIPTION
In tree SGX driver introduces new interfaces to handle enclave's exceptions ([details](https://www.kernel.org/doc/html/latest/x86/sgx.html?highlight=sgx#c.vdso_sgx_enter_enclave_t)) . Current Occlum's SDK implementation cannot get enough information when handling Occlum's specific interrupt (SIG64) and exception (SEGV). To work around it , current Occlum's SDK do not use the interface provided by VDSO **temporarily**.