### PR TITLE
Improve SGX Protected FS

### DIFF
--- a/common/inc/sgx_tprotected_fs.h
+++ b/common/inc/sgx_tprotected_fs.h
@@ -109,6 +109,29 @@ SGX_FILE* SGXAPI sgx_fopen_auto_key(const char* filename, const char* mode);
 SGX_FILE* SGXAPI sgx_fopen_integrity_only(const char* filename, const char* mode);
 
 
+/* sgx_fopen_ex
+ *  Purpose: Expert version of sgx_fopen/sgx_fopen_auto_key which is used if you want to control the internal `cache size`.
+ *           The specified `cache size` must be page (4KB by default) aligned.
+ *           Note that `sgx_fexport_auto_key` and `sgx_fimport_auto_key` don't support configuring `cache_size` right now
+ *
+ *  Parameters:
+ *      filename - [IN] the name of the file to open/create.
+ *      mode - [IN] open mode. only supports 'r' or 'w' or 'a' (one and only one of them must be present), and optionally 'b' and/or '+'.
+ *      key - [IN] encryption key that will be used for the file encryption.
+ *            If it's NULL, we will swtich back to `sgx_fopen_auto_key and use enclave's seal key to protect the file
+ *      NOTE - the key is actually used as a KDK (key derivation key) and only for the meta-data node, and not used directly for the encryption of any part of the file
+ *             this is important in order to prevent hitting the key wear-out problem, and some other issues with GCM encryptions using the same key
+ *      cache_size - [IN] Internal cache size in byte, which used to cache R/W data in enclave before flush to actual file
+ *                   It must larger than default cache size (192KB), and must be page (4KB by default) aligned
+ *                   a) Please make sure enclave heap is enough for the `cache`, e.g. Configure enough heap in enclave config file
+ *                   b) All the data in cache may lost after exeception, please try to call `sgx_fflush` explicitly to avoid data loss
+ *
+ *  Return value:
+ *     SGX_FILE*  - pointer to the newly created file handle, NULL if an error occurred - check errno for the error code.
+*/
+SGX_FILE* SGXAPI sgx_fopen_ex(const char* filename, const char* mode, const sgx_key_128bit_t *key, const uint64_t cache_size);
+
+
 /* sgx_fwrite
  *  Purpose: write data to a file (see c++ fwrite documentation for more details).
  *

--- a/sdk/protected_fs/sgx_tprotected_fs/file_crypto.cpp
+++ b/sdk/protected_fs/sgx_tprotected_fs/file_crypto.cpp
@@ -313,5 +313,3 @@ bool protected_fs_file::restore_current_meta_data_key(const sgx_aes_gcm_128bit_k
 
 	return true;
 }
-
-

--- a/sdk/protected_fs/sgx_tprotected_fs/file_flush.cpp
+++ b/sdk/protected_fs/sgx_tprotected_fs/file_flush.cpp
@@ -37,7 +37,7 @@
 
 #include <sgx_trts.h>
 
-bool protected_fs_file::flush(/*bool mc*/)
+bool protected_fs_file::flush()
 {
 	bool result = false;
 
@@ -56,7 +56,7 @@ bool protected_fs_file::flush(/*bool mc*/)
 		return false;
 	}
 
-	result = internal_flush(/*mc,*/ true);
+	result = internal_flush(true);
 	if (result == false)
 	{
 		assert(file_status != SGX_FILE_STATUS_OK);
@@ -70,18 +70,11 @@ bool protected_fs_file::flush(/*bool mc*/)
 }
 
 
-bool protected_fs_file::internal_flush(/*bool mc,*/ bool flush_to_disk)
+bool protected_fs_file::internal_flush(bool flush_to_disk)
 {
 	if (need_writing == false) // no changes at all
 		return true;
 
-/*
-	if (mc == true && encrypted_part_plain.mc_value > (UINT_MAX-2))
-	{
-		last_error = SGX_ERROR_FILE_MONOTONIC_COUNTER_AT_MAX;
-		return false;
-	}
-*/
 	if (encrypted_part_plain.size > MD_USER_DATA_SIZE && root_mht.need_writing == true) // otherwise it's just one write - the meta-data node
 	{
 		if (_RECOVERY_HOOK_(0) || write_recovery_file() != true)
@@ -104,44 +97,17 @@ bool protected_fs_file::internal_flush(/*bool mc,*/ bool flush_to_disk)
 		}
 	}
 
-/*
-	sgx_status_t status;
-
-	if (mc == true)
-	{
-		// increase monotonic counter local value - only if everything is ok, we will increase the real counter
-		if (encrypted_part_plain.mc_value == 0)
-		{
-			// no monotonic counter so far, need to create a new one
-			status = sgx_create_monotonic_counter(&encrypted_part_plain.mc_uuid, &encrypted_part_plain.mc_value);
-			if (status != SGX_SUCCESS)
-			{
-				clear_update_flag();
-				file_status = SGX_FILE_STATUS_FLUSH_ERROR;
-				last_error = status;
-				return false;
-			}
-		}
-		encrypted_part_plain.mc_value++;
-	}
-*/
 	if (_RECOVERY_HOOK_(3) || update_meta_data_node() != true)
 	{
 		clear_update_flag();
-		/*
-		if (mc == true)
-			encrypted_part_plain.mc_value--; // don't have to do this as the file cannot be fixed, but doing it anyway to prevent future errors
-		*/
+
 		file_status = SGX_FILE_STATUS_CRYPTO_ERROR; // this is something that shouldn't happen, can't fix this...
 		return false;
 	}
 
 	if (_RECOVERY_HOOK_(4) || write_all_changes_to_disk(flush_to_disk) != true)
 	{
-		//if (mc == false)
-			file_status = SGX_FILE_STATUS_WRITE_TO_DISK_FAILED; // special case, need only to repeat write_all_changes_to_disk in order to repair it
-		//else
-			//file_status = SGX_FILE_STATUS_WRITE_TO_DISK_FAILED_NEED_MC; // special case, need to repeat write_all_changes_to_disk AND increase the monotonic counter in order to repair it
+		file_status = SGX_FILE_STATUS_WRITE_TO_DISK_FAILED; // special case, need only to repeat write_all_changes_to_disk in order to repair it
 
 		return false;
 	}
@@ -156,20 +122,7 @@ bool protected_fs_file::internal_flush(/*bool mc,*/ bool flush_to_disk)
 		erase_recovery_file();
 	}
 */
-/*
-	if (mc == true)
-	{
-		uint32_t mc_value;
-		status = sgx_increment_monotonic_counter(&encrypted_part_plain.mc_uuid, &mc_value);
-		if (status != SGX_SUCCESS)
-		{
-			file_status = SGX_FILE_STATUS_MC_NOT_INCREMENTED; // special case - need only to increase the MC in order to repair it
-			last_error = status;
-			return false;
-		}
-		assert(mc_value == encrypted_part_plain.mc_value);
-	}
-*/
+
 	return true;
 }
 
@@ -577,5 +530,3 @@ void protected_fs_file::erase_recovery_file()
 	status = u_sgxprotectedfs_remove(&result32, recovery_filename);
 	(void)status; // don't care if it succeeded or failed...just remove the warning
 }
-
-

--- a/sdk/protected_fs/sgx_tprotected_fs/file_init.cpp
+++ b/sdk/protected_fs/sgx_tprotected_fs/file_init.cpp
@@ -67,13 +67,13 @@ bool protected_fs_file::cleanup_filename(const char* src, char* dest)
 }
 
 
-protected_fs_file::protected_fs_file(const char* filename, const char* mode, const sgx_aes_gcm_128bit_key_t* import_key, const sgx_aes_gcm_128bit_key_t* kdk_key, bool _integrity_only)
+protected_fs_file::protected_fs_file(const char* filename, const char* mode, const sgx_aes_gcm_128bit_key_t* import_key, const sgx_aes_gcm_128bit_key_t* kdk_key, bool _integrity_only, const uint64_t cache_page)
 {
 	sgx_status_t status = SGX_SUCCESS;
 	uint8_t result = 0;
 	int32_t result32 = 0;
 
-	init_fields();
+	init_fields(cache_page);
 
 	if (filename == NULL || mode == NULL ||
 		strnlen(filename, 1) == 0 || strnlen(mode, 1) == 0)
@@ -249,7 +249,7 @@ protected_fs_file::protected_fs_file(const char* filename, const char* mode, con
 }
 
 
-void protected_fs_file::init_fields()
+void protected_fs_file::init_fields(const uint64_t cache_page)
 {
 	meta_data_node_number = 0;
 	memset(&file_meta_data, 0, sizeof(meta_data_node_t));
@@ -277,13 +277,16 @@ void protected_fs_file::init_fields()
 	open_mode.raw = 0;
 	use_user_kdk_key = 0;
 	master_key_count = 0;
+	max_cache_page = 0;
 
 	recovery_filename[0] = '\0';
 
-	memset(&mutex, 0, sizeof(sgx_thread_mutex_t));
+	max_cache_page = cache_page;
 
-	// set hash size to fit MAX_PAGES_IN_CACHE
-	cache.rehash(MAX_PAGES_IN_CACHE);
+	// set hash size
+	cache.rehash(max_cache_page);
+
+	memset(&mutex, 0, sizeof(sgx_thread_mutex_t));
 }
 
 
@@ -480,51 +483,6 @@ bool protected_fs_file::init_existing_file(const char* filename, const char* cle
 		return false;
 	}
 
-/*
-	sgx_mc_uuid_t empty_mc_uuid = {0};
-
-	// check if the file contains an active monotonic counter
-	if (consttime_memequal(&empty_mc_uuid, &encrypted_part_plain.mc_uuid, sizeof(sgx_mc_uuid_t)) == 0)
-	{
-		uint32_t mc_value = 0;
-
-		status = sgx_read_monotonic_counter(&encrypted_part_plain.mc_uuid, &mc_value);
-		if (status != SGX_SUCCESS)
-		{
-			last_error = status;
-			return false;
-		}
-
-		if (encrypted_part_plain.mc_value < mc_value)
-		{
-			last_error = SGX_ERROR_FILE_MONOTONIC_COUNTER_IS_BIGGER;
-			return false;
-		}
-
-		if (encrypted_part_plain.mc_value == mc_value + 1) // can happen if AESM failed - file value stayed one higher
-		{
-			sgx_status_t status = sgx_increment_monotonic_counter(&encrypted_part_plain.mc_uuid, &mc_value);
-			if (status != SGX_SUCCESS)
-			{
-				file_status = SGX_FILE_STATUS_MC_NOT_INCREMENTED;
-				last_error = status;
-				return false;
-			}
-		}
-
-		if (encrypted_part_plain.mc_value != mc_value)
-		{
-			file_status = SGX_FILE_STATUS_CORRUPTED;
-			last_error = SGX_ERROR_UNEXPECTED;
-			return false;
-		}
-	}
-	else
-	{
-		assert(encrypted_part_plain.mc_value == 0);
-		encrypted_part_plain.mc_value = 0; // do this anyway for release...
-	}
-*/
 	if (encrypted_part_plain.size > MD_USER_DATA_SIZE)
 	{
 		// read the root node of the mht
@@ -679,4 +637,3 @@ bool protected_fs_file::pre_close(sgx_key_128bit_t* key, bool import)
 
 	return retval;
 }
-

--- a/sdk/protected_fs/sgx_tprotected_fs/file_other.cpp
+++ b/sdk/protected_fs/sgx_tprotected_fs/file_other.cpp
@@ -45,102 +45,6 @@ int32_t protected_fs_file::remove(const char* filename)
 	sgx_status_t status;
 	int32_t result32 = 0;
 
-/*
-	void* file = NULL;
-	int64_t real_file_size = 0;
-
-	if (filename == NULL)
-		return 1;
-
-	meta_data_node_t* file_meta_data = NULL;
-	meta_data_encrypted_t* encrypted_part_plain = NULL;
-
-	// if we have a problem in any of the stages, we simply jump to the end and try to remove the file...
-	do {
-		status = u_sgxprotectedfs_check_if_file_exists(&result, filename);
-		if (status != SGX_SUCCESS)
-			break;
-
-		if (result == 0)
-		{
-			errno = EINVAL;
-			return 1; // no such file, or file locked so we can't delete it anyways
-		}
-
-		try {
-			file_meta_data = new meta_data_node_t;
-			encrypted_part_plain = new meta_data_encrypted_t;
-		}
-		catch (std::bad_alloc e) {
-			break;
-		}
-
-		status = u_sgxprotectedfs_exclusive_file_open(&file, filename, 1, &real_file_size, &result32);
-		if (status != SGX_SUCCESS || file == NULL)
-			break;
-
-		if (real_file_size == 0 || real_file_size % NODE_SIZE != 0)
-			break; // empty file or not an SGX protected FS file
-
-		// might be an SGX protected FS file
-		status = u_sgxprotectedfs_fread_node(&result32, file, 0, (uint8_t*)file_meta_data, NODE_SIZE);
-		if (status != SGX_SUCCESS || result32 != 0)
-			break;
-
-		if (file_meta_data->plain_part.major_version != SGX_FILE_MAJOR_VERSION)
-			break;
-
-		sgx_aes_gcm_128bit_key_t zero_key_id = {0};
-		sgx_aes_gcm_128bit_key_t key = {0};
-		if (consttime_memequal(&file_meta_data->plain_part.key_id, &zero_key_id, sizeof(sgx_aes_gcm_128bit_key_t)) == 1)
-			break; // shared file - no monotonic counter
-
-		sgx_key_request_t key_request = {0};
-		key_request.key_name = SGX_KEYSELECT_SEAL;
-		key_request.key_policy = SGX_KEYPOLICY_MRENCLAVE;
-		memcpy(&key_request.key_id, &file_meta_data->plain_part.key_id, sizeof(sgx_key_id_t));
-
-		status = sgx_get_key(&key_request, &key);
-		if (status != SGX_SUCCESS)
-			break;
-
-		status = sgx_rijndael128GCM_decrypt(&key,
-											file_meta_data->encrypted_part, sizeof(meta_data_encrypted_blob_t),
-											(uint8_t*)encrypted_part_plain,
-											file_meta_data->plain_part.meta_data_iv, SGX_AESGCM_IV_SIZE,
-											NULL, 0,
-											&file_meta_data->plain_part.meta_data_gmac);
-		if (status != SGX_SUCCESS)
-			break;
-
-		sgx_mc_uuid_t empty_mc_uuid = {0};
-		if (consttime_memequal(&empty_mc_uuid, &encrypted_part_plain->mc_uuid, sizeof(sgx_mc_uuid_t)) == 0)
-		{
-			status = sgx_destroy_monotonic_counter(&encrypted_part_plain->mc_uuid);
-			if (status != SGX_SUCCESS)
-				break;
-
-			// monotonic counter was deleted, mission accomplished!!
-		}
-	}
-	while (0);
-
-	// cleanup
-	if (file_meta_data != NULL)
-		delete file_meta_data;
-
-	if (encrypted_part_plain != NULL)
-	{
-		// scrub the encrypted part
-		memset_s(encrypted_part_plain, sizeof(meta_data_encrypted_t), 0, sizeof(meta_data_encrypted_t));
-		delete encrypted_part_plain;
-	}
-
-	if (file != NULL)
-		u_sgxprotectedfs_fclose(&result32, file);
-
-*/
-
 	// do the actual file removal
 	status = u_sgxprotectedfs_remove(&result32, filename);
 	if (status != SGX_SUCCESS)
@@ -196,13 +100,6 @@ int protected_fs_file::seek(int64_t new_offset, int origin)
 		sgx_thread_mutex_unlock(&mutex);
 		return -1;
 	}
-
-	//if (open_mode.binary == 0 && origin != SEEK_SET && new_offset != 0)
-	//{
-	//	last_error = EINVAL;
-	//	sgx_thread_mutex_unlock(&mutex);
-	//	return -1;
-	//}
 
 	int result = -1;
 
@@ -298,33 +195,6 @@ void protected_fs_file::clear_error()
 			file_status = SGX_FILE_STATUS_OK;
 		}
 	}
-
-/*
-	if (file_status == SGX_FILE_STATUS_WRITE_TO_DISK_FAILED_NEED_MC)
-	{
-		if (write_all_changes_to_disk(true) == true)
-		{
-			need_writing = false;
-			file_status = SGX_FILE_STATUS_MC_NOT_INCREMENTED; // fall through...next 'if' should take care of this one
-		}
-	}
-
-	if ((file_status == SGX_FILE_STATUS_MC_NOT_INCREMENTED) &&
-		(encrypted_part_plain.mc_value <= (UINT_MAX-2)))
-	{
-		uint32_t mc_value;
-		sgx_status_t status = sgx_increment_monotonic_counter(&encrypted_part_plain.mc_uuid, &mc_value);
-		if (status == SGX_SUCCESS)
-		{
-			assert(mc_value == encrypted_part_plain.mc_value);
-			file_status = SGX_FILE_STATUS_OK;
-		}
-		else
-		{
-			last_error = status;
-		}
-	}
-*/
 
 	if (file_status == SGX_FILE_STATUS_OK)
 	{

--- a/sdk/protected_fs/sgx_tprotected_fs/file_read_write.cpp
+++ b/sdk/protected_fs/sgx_tprotected_fs/file_read_write.cpp
@@ -312,7 +312,7 @@ void get_node_numbers(uint64_t offset, uint64_t* mht_node_number, uint64_t* data
 	// node 1 - mht
 	// nodes 2-97 - data (ATTACHED_DATA_NODES_COUNT == 96)
 	// node 98 - mht
-	// node 99-195 - data
+	// node 99-194 - data
 	// etc.
 	uint64_t _mht_node_number;
 	uint64_t _data_node_number;
@@ -370,7 +370,7 @@ file_data_node_t* protected_fs_file::get_data_node()
 	}
 
 	// even if we didn't get the required data_node, we might have read other nodes in the process
-	while (cache.size() > MAX_PAGES_IN_CACHE)
+	while (cache.size() > max_cache_page)
 	{
 		void* data = cache.get_last();
 		assert(data != NULL);
@@ -678,4 +678,3 @@ file_mht_node_t* protected_fs_file::read_mht_node(uint64_t mht_node_number)
 
 	return file_mht_node;
 }
-

--- a/sdk/protected_fs/sgx_tprotected_fs/lru_cache.cpp
+++ b/sdk/protected_fs/sgx_tprotected_fs/lru_cache.cpp
@@ -61,7 +61,7 @@ lru_cache::~lru_cache()
 }
 
 
-void lru_cache::rehash(uint32_t size_)
+void lru_cache::rehash(uint64_t size_)
 {
 	map.rehash(size_);
 }
@@ -272,4 +272,3 @@ void lru_cache::remove_last()
 	map.erase(key);
 	delete map_node;
 }
-

--- a/sdk/protected_fs/sgx_tprotected_fs/lru_cache.h
+++ b/sdk/protected_fs/sgx_tprotected_fs/lru_cache.h
@@ -83,7 +83,7 @@ public:
 	lru_cache();
 	~lru_cache();
 
-	void rehash(uint32_t size_);
+	void rehash(uint64_t size_);
 
 	bool add(uint64_t key, void* p);
 	void* get(uint64_t key);

--- a/sdk/protected_fs/sgx_tprotected_fs/protected_fs_nodes.h
+++ b/sdk/protected_fs/sgx_tprotected_fs/protected_fs_nodes.h
@@ -154,4 +154,3 @@ typedef struct _recovery_node
 #pragma pack(pop)
 
 #endif // _PROTECTED_FS_NODES_H_
-

--- a/sdk/protected_fs/sgx_uprotected_fs/sgx_uprotected_fs.cpp
+++ b/sdk/protected_fs/sgx_uprotected_fs/sgx_uprotected_fs.cpp
@@ -248,6 +248,12 @@ int32_t u_sgxprotectedfs_fclose(void* f)
 	else
 		flock(fd, LOCK_UN);
 
+	if ((result = fsync(fd)) != 0)
+	{
+		DEBUG_PRINT("fsync returned %d\n", result);
+		return -1;
+	}
+
 	if ((result = fclose(file)) != 0)
 	{
 		if (errno != 0)
@@ -278,6 +284,12 @@ uint8_t u_sgxprotectedfs_fflush(void* f)
 	if ((result = fflush(file)) != 0)
 	{
 		DEBUG_PRINT("fflush returned %d\n", result);
+		return 1;
+	}
+
+	if ((result = fsync(fileno(file))) != 0)
+	{
+		DEBUG_PRINT("fsync returned %d\n", result);
 		return 1;
 	}
 


### PR DESCRIPTION
This PR includes:
- Support parameterized cache size of SGX PFS (apply intel's patch)
  - This can benefit user to tune the `cache_size` and gain better io performance
- Add `fsync` to `sgx_fflush` and `sgx_fclose` to ensure persistency
  - Old version of PFS makes no promise about whether data in OS's buffer is written to the actual storage media