### PR TITLE
Fix bug in get_first_executable_segment_info()

### DIFF
--- a/sdk/trts/linux/elf_parser.c
+++ b/sdk/trts/linux/elf_parser.c
@@ -570,7 +570,7 @@ int get_first_executable_segment_info(const void *enclave_base,
 
     for (; phnum < ehdr->e_phnum; phnum++, phdr++)
     {
-        if (phdr->p_type == PT_LOAD && phdr->p_flags | PF_X)
+        if (phdr->p_type == PT_LOAD && phdr->p_flags & PF_X)
         {
             *segment_start_addr = (size_t)enclave_base + phdr->p_vaddr;
             *segment_size = phdr->p_memsz;


### PR DESCRIPTION
The first executable segment (contains code section) should have `PF_X` flag.

For Ubuntu 18.04 (using the native complier toolchain), everything works well since the code section lays in the first program header with `PT_LOAD` type:
<img width="1440" alt="截屏2022-09-09 15 27 02" src="https://user-images.githubusercontent.com/24669680/189295597-6bd89151-4160-4ee8-9d71-cec7d9b374e9.png">

But after we have updated the docker environment to Ubuntu 20.04  (using the native complier toolchain),  the code section lays in the second program header with `PT_LOAD` type:
<img width="1099" alt="截屏2022-09-09 15 30 30" src="https://user-images.githubusercontent.com/24669680/189296268-d29f2680-7a38-4644-bde5-831c97c7ccc3.png">

So before such fix in Ubuntu 20.04, all the exceptions we clarify in the `internal_handle_exception()`(sdk/trts/trts_veh.cpp) is always non-standard exception.

This PR is for its fix.
